### PR TITLE
Fix dynamic notch position bug when screen resolution changes

### DIFF
--- a/Sources/DynamicNotchKit/DynamicNotch.swift
+++ b/Sources/DynamicNotchKit/DynamicNotch.swift
@@ -5,6 +5,7 @@
 //  Created by Kai Azim on 2023-08-24.
 //
 
+import Combine
 import SwiftUI
 
 // MARK: - DynamicNotch
@@ -25,6 +26,7 @@ public class DynamicNotch<Content>: ObservableObject where Content: View {
     // Notch Closing Properties
     @Published var isMouseInside: Bool = false // If the mouse is inside, the notch will not auto-hide
     private var timer: Timer?
+    private var subscription: AnyCancellable?
 
     // Notch Style
     private var notchStyle: Style = .notch
@@ -51,6 +53,12 @@ public class DynamicNotch<Content>: ObservableObject where Content: View {
     public init(style: DynamicNotch.Style = .auto, @ViewBuilder content: @escaping () -> Content) {
         self.content = content
         self.notchStyle = style
+        self.subscription = NotificationCenter.default
+            .publisher(for: NSApplication.didChangeScreenParametersNotification)
+            .sink { [weak self] _ in
+                guard let self, let screen = NSScreen.screens.first else { return }
+                initializeWindow(screen: screen)
+            }
     }
 }
 


### PR DESCRIPTION
Add subscription to run `initializeWindow` when the screen parameters change to re-position the dynamic notch