### PR TITLE
Add support for using SwiftUI views as images in the dynamic notch

### DIFF
--- a/Sources/DynamicNotchKit/DynamicNotchInfo.swift
+++ b/Sources/DynamicNotchKit/DynamicNotchInfo.swift
@@ -7,33 +7,47 @@
 
 import SwiftUI
 
-internal final class DynamicNotchInfoPublisher: ObservableObject {
-    @Published var icon: Image?
+internal final class DynamicNotchInfoPublisher<IconView>: ObservableObject where IconView: View {
+    @Published var iconView: IconView?
     @Published var iconColor: Color
     @Published var title: String
     @Published var description: String?
 
-    init(icon: Image?, iconColor: Color, title: String, description: String? = nil) {
-        self.icon = icon
+    init(icon: Image?, iconColor: Color, title: String, description: String? = nil) where IconView == Image {
+        self.iconView = icon ?? nil
+        self.iconColor = iconColor
+        self.title = title
+        self.description = description
+    }
+
+    init(iconView: IconView?, title: String, description: String? = nil) {
+        self.iconView = iconView
+        self.iconColor = .clear
+        self.title = title
+        self.description = description
+    }
+
+    @MainActor
+    func publish(icon: Image?, iconColor: Color, title: String, description: String?) where IconView == Image {
+        self.iconView = icon
         self.iconColor = iconColor
         self.title = title
         self.description = description
     }
 
     @MainActor
-    func publish(icon: Image?, iconColor: Color, title: String, description: String?) {
-        self.icon = icon
-        self.iconColor = iconColor
+    func publish(icon: IconView?, title: String, description: String?) {
+        self.iconView = icon
         self.title = title
         self.description = description
     }
 }
 
-public class DynamicNotchInfo {
+public class DynamicNotchInfo<IconView> where IconView: View {
     private var internalDynamicNotch: DynamicNotch<InfoView>
-    private let publisher: DynamicNotchInfoPublisher
+    private let publisher: DynamicNotchInfoPublisher<IconView>
 
-    public init(contentID: UUID = .init(), icon: Image! = nil, title: String, description: String? = nil, iconColor: Color = .white, style: DynamicNotch<InfoView>.Style = .auto) {
+    public init(contentID: UUID = .init(), icon: Image! = nil, title: String, description: String? = nil, iconColor: Color = .white, style: DynamicNotch<InfoView>.Style = .auto) where IconView == Image {
         let publisher = DynamicNotchInfoPublisher(icon: icon, iconColor: iconColor, title: title, description: description)
         self.publisher = publisher
         internalDynamicNotch = DynamicNotch(contentID: contentID, style: style) {
@@ -41,10 +55,25 @@ public class DynamicNotchInfo {
         }
     }
 
+    public init(contentID: UUID = .init(), iconView: IconView, title: String, description: String? = nil, style: DynamicNotch<InfoView>.Style = .auto) {
+        let publisher = DynamicNotchInfoPublisher<IconView>(iconView: iconView, title: title, description: description)
+        self.publisher = publisher
+        internalDynamicNotch = DynamicNotch(contentID: contentID, style: style) {
+            InfoView(publisher: publisher)
+        }
+    }
+
     @MainActor
-    public func setContent(contentID: UUID = .init(), icon: Image? = nil, title: String, description: String? = nil, iconColor: Color = .white) {
+    public func setContent(contentID: UUID = .init(), icon: Image? = nil, title: String, description: String? = nil, iconColor: Color = .white) where IconView == Image {
         withAnimation {
             publisher.publish(icon: icon, iconColor: iconColor, title: title, description: description)
+        }
+    }
+
+    @MainActor
+    public func setContent(contentID: UUID = .init(), iconView: IconView? = nil, title: String, description: String? = nil) {
+        withAnimation {
+            publisher.publish(icon: iconView, title: title, description: description)
         }
     }
 
@@ -63,9 +92,9 @@ public class DynamicNotchInfo {
 
 public extension DynamicNotchInfo {
     struct InfoView: View {
-        private var publisher: DynamicNotchInfoPublisher
+        private var publisher: DynamicNotchInfoPublisher<IconView>
 
-        init(publisher: DynamicNotchInfoPublisher) {
+        init(publisher: DynamicNotchInfoPublisher<IconView>) {
             self.publisher = publisher
         }
 
@@ -80,19 +109,21 @@ public extension DynamicNotchInfo {
     }
 
     struct InfoImageView: View {
-        @ObservedObject private var publisher: DynamicNotchInfoPublisher
+        @ObservedObject private var publisher: DynamicNotchInfoPublisher<IconView>
 
-        init(publisher: DynamicNotchInfoPublisher) {
+        init(publisher: DynamicNotchInfoPublisher<IconView>) {
             self.publisher = publisher
         }
 
         public var body: some View {
-            if let image = publisher.icon {
+            if let image = publisher.iconView as? Image {
                 image
                     .resizable()
                     .foregroundStyle(publisher.iconColor)
                     .padding(3)
                     .scaledToFit()
+            } else if let iconView = publisher.iconView {
+                iconView
             } else {
                 Image(nsImage: NSApplication.shared.applicationIconImage)
                     .resizable()
@@ -103,9 +134,9 @@ public extension DynamicNotchInfo {
     }
 
     struct InfoTextView: View {
-        @ObservedObject private var publisher: DynamicNotchInfoPublisher
+        @ObservedObject private var publisher: DynamicNotchInfoPublisher<IconView>
 
-        init(publisher: DynamicNotchInfoPublisher) {
+        init(publisher: DynamicNotchInfoPublisher<IconView>) {
             self.publisher = publisher
         }
 

--- a/Sources/DynamicNotchKit/DynamicNotchInfo.swift
+++ b/Sources/DynamicNotchKit/DynamicNotchInfo.swift
@@ -14,32 +14,32 @@ internal final class DynamicNotchInfoPublisher<IconView>: ObservableObject where
     @Published var description: String?
 
     init(icon: Image?, iconColor: Color, title: String, description: String? = nil) where IconView == Image {
-        self.iconView = icon ?? nil
+        self.iconView = icon
         self.iconColor = iconColor
         self.title = title
         self.description = description
     }
 
-    init(iconView: IconView?, title: String, description: String? = nil) {
-        self.iconView = iconView
-        self.iconColor = .clear
+    init(title: String, description: String? = nil, iconView: (() -> IconView)?) {
         self.title = title
         self.description = description
+        self.iconColor = .clear
+        self.iconView = iconView?()
     }
 
     @MainActor
     func publish(icon: Image?, iconColor: Color, title: String, description: String?) where IconView == Image {
-        self.iconView = icon
-        self.iconColor = iconColor
         self.title = title
         self.description = description
+        self.iconView = icon
+        self.iconColor = iconColor
     }
 
     @MainActor
     func publish(icon: IconView?, title: String, description: String?) {
-        self.iconView = icon
         self.title = title
         self.description = description
+        self.iconView = iconView
     }
 }
 
@@ -55,8 +55,8 @@ public class DynamicNotchInfo<IconView> where IconView: View {
         }
     }
 
-    public init(contentID: UUID = .init(), iconView: IconView, title: String, description: String? = nil, style: DynamicNotch<InfoView>.Style = .auto) {
-        let publisher = DynamicNotchInfoPublisher<IconView>(iconView: iconView, title: title, description: description)
+    public init(contentID: UUID = .init(), title: String, description: String? = nil, style: DynamicNotch<InfoView>.Style = .auto, iconView: (() -> IconView)? = nil) {
+        let publisher = DynamicNotchInfoPublisher<IconView>(title: title, description: description, iconView: iconView)
         self.publisher = publisher
         internalDynamicNotch = DynamicNotch(contentID: contentID, style: style) {
             InfoView(publisher: publisher)
@@ -71,7 +71,7 @@ public class DynamicNotchInfo<IconView> where IconView: View {
     }
 
     @MainActor
-    public func setContent(contentID: UUID = .init(), iconView: IconView? = nil, title: String, description: String? = nil) {
+    public func setContent(contentID: UUID = .init(), title: String, description: String? = nil, iconView: IconView? = nil) {
         withAnimation {
             publisher.publish(icon: iconView, title: title, description: description)
         }

--- a/Sources/DynamicNotchKit/DynamicNotchProgress.swift
+++ b/Sources/DynamicNotchKit/DynamicNotchProgress.swift
@@ -110,7 +110,7 @@ public extension DynamicNotchProgress {
         }
     }
 
-    public struct ProgressRing: View {
+    struct ProgressRing: View {
         @Binding var target: CGFloat
         let color: Color
         let thickness: CGFloat


### PR DESCRIPTION
This PR adds support for using custom views as icons in the dynamic notch info.
It tries to keep the current API intact by adding functions and initializers that act as overloads.

```swift
init(…) where IconView: Image 
func doSomething() where IconView: Image
```

This works for me locally but it might still some more tweaks, please try it out and verify that something didn't break outside of my environment ❤️ 

### Screengrab

https://github.com/user-attachments/assets/dad0b8d0-89d3-46aa-83d6-c1ae1b838928


