### PR TITLE
DynamicNotchInfo | Add text color option

### DIFF
--- a/Sources/DynamicNotchKit/DynamicNotchInfo.swift
+++ b/Sources/DynamicNotchKit/DynamicNotchInfo.swift
@@ -36,8 +36,8 @@ public class DynamicNotchInfo {
     private var internalDynamicNotch: DynamicNotch<InfoView>
     private let publisher: DynamicNotchInfoPublisher
 
-    public init(contentID: UUID = .init(), icon: Image! = nil, title: String, description: String? = nil, iconColor: Color = .white, textColor: Color? = nil, style: DynamicNotch<InfoView>.Style = .auto) {
-        let publisher = DynamicNotchInfoPublisher(icon: icon, iconColor: iconColor, title: title, description: description, textColor: textColor ?? .white)
+    public init(contentID: UUID = .init(), icon: Image! = nil, title: String, description: String? = nil, iconColor: Color = .white, textColor: Color = .white, style: DynamicNotch<InfoView>.Style = .auto) {
+        let publisher = DynamicNotchInfoPublisher(icon: icon, iconColor: iconColor, title: title, description: description, textColor: textColor)
         self.publisher = publisher
         internalDynamicNotch = DynamicNotch(contentID: contentID, style: style) {
             InfoView(publisher: publisher)

--- a/Sources/DynamicNotchKit/DynamicNotchInfo.swift
+++ b/Sources/DynamicNotchKit/DynamicNotchInfo.swift
@@ -12,20 +12,23 @@ internal final class DynamicNotchInfoPublisher: ObservableObject {
     @Published var iconColor: Color
     @Published var title: String
     @Published var description: String?
+    @Published var textColor: Color
 
-    init(icon: Image?, iconColor: Color, title: String, description: String? = nil) {
+    init(icon: Image?, iconColor: Color, title: String, description: String? = nil, textColor: Color) {
         self.icon = icon
         self.iconColor = iconColor
         self.title = title
         self.description = description
+        self.textColor = textColor
     }
 
     @MainActor
-    func publish(icon: Image?, iconColor: Color, title: String, description: String?) {
+    func publish(icon: Image?, iconColor: Color, title: String, description: String?, textColor: Color) {
         self.icon = icon
         self.iconColor = iconColor
         self.title = title
         self.description = description
+        self.textColor = textColor
     }
 }
 
@@ -33,8 +36,13 @@ public class DynamicNotchInfo {
     private var internalDynamicNotch: DynamicNotch<InfoView>
     private let publisher: DynamicNotchInfoPublisher
 
-    public init(contentID: UUID = .init(), icon: Image! = nil, title: String, description: String? = nil, iconColor: Color = .white, style: DynamicNotch<InfoView>.Style = .auto) {
-        let publisher = DynamicNotchInfoPublisher(icon: icon, iconColor: iconColor, title: title, description: description)
+    public init(contentID: UUID = .init(), icon: Image! = nil, title: String, description: String? = nil, iconColor: Color = .white, textColor: Color? = nil, style: DynamicNotch<InfoView>.Style = .auto) {
+        let textColor: Color = if let textColor {
+            textColor
+        } else {
+            .white
+        }
+        let publisher = DynamicNotchInfoPublisher(icon: icon, iconColor: iconColor, title: title, description: description, textColor: textColor)
         self.publisher = publisher
         internalDynamicNotch = DynamicNotch(contentID: contentID, style: style) {
             InfoView(publisher: publisher)
@@ -42,9 +50,9 @@ public class DynamicNotchInfo {
     }
 
     @MainActor
-    public func setContent(contentID: UUID = .init(), icon: Image? = nil, title: String, description: String? = nil, iconColor: Color = .white) {
+    public func setContent(contentID: UUID = .init(), icon: Image? = nil, title: String, description: String? = nil, iconColor: Color = .white, textColor: Color) {
         withAnimation {
-            publisher.publish(icon: icon, iconColor: iconColor, title: title, description: description)
+            publisher.publish(icon: icon, iconColor: iconColor, title: title, description: description, textColor: textColor)
         }
     }
 
@@ -113,9 +121,10 @@ public extension DynamicNotchInfo {
             VStack(alignment: .leading, spacing: publisher.description != nil ? nil : 0) {
                 Text(publisher.title)
                     .font(.headline)
+                    .foregroundStyle(publisher.textColor)
                 Text(publisher.description ?? "")
-                    .foregroundStyle(.secondary)
                     .font(.caption2)
+                    .foregroundStyle(publisher.textColor.opacity(0.75))
                     .opacity(publisher.description != nil ? 1 : 0)
                     .frame(maxHeight: publisher.description != nil ? nil : 0)
             }
@@ -124,7 +133,7 @@ public extension DynamicNotchInfo {
 }
 
 struct DynamicNotchInfo_Previews: PreviewProvider {
-    static let publisher = DynamicNotchInfoPublisher(icon: nil, iconColor: .blue, title: "testing")
+    static let publisher = DynamicNotchInfoPublisher(icon: nil, iconColor: .blue, title: "testing", textColor: .black)
     static var previews: some View {
         VStack {
             DynamicNotchInfo.InfoView(publisher: publisher)

--- a/Sources/DynamicNotchKit/DynamicNotchInfo.swift
+++ b/Sources/DynamicNotchKit/DynamicNotchInfo.swift
@@ -37,12 +37,7 @@ public class DynamicNotchInfo {
     private let publisher: DynamicNotchInfoPublisher
 
     public init(contentID: UUID = .init(), icon: Image! = nil, title: String, description: String? = nil, iconColor: Color = .white, textColor: Color? = nil, style: DynamicNotch<InfoView>.Style = .auto) {
-        let textColor: Color = if let textColor {
-            textColor
-        } else {
-            .white
-        }
-        let publisher = DynamicNotchInfoPublisher(icon: icon, iconColor: iconColor, title: title, description: description, textColor: textColor)
+        let publisher = DynamicNotchInfoPublisher(icon: icon, iconColor: iconColor, title: title, description: description, textColor: textColor ?? .white)
         self.publisher = publisher
         internalDynamicNotch = DynamicNotch(contentID: contentID, style: style) {
             InfoView(publisher: publisher)

--- a/Sources/DynamicNotchKit/DynamicNotchProgress.swift
+++ b/Sources/DynamicNotchKit/DynamicNotchProgress.swift
@@ -10,27 +10,27 @@ import SwiftUI
 public class DynamicNotchProgress {
     private var internalDynamicNotch: DynamicNotch<InfoView>
 
-    public init(progress: Binding<CGFloat>, title: String, description: String? = nil, progressText: Bool = false, progressBarColor: Color = .white, style: DynamicNotch<InfoView>.Style = .auto) {
+    public init(progress: Binding<CGFloat>, title: String, description: String? = nil, progressText: Bool = false, progressBarColor: Color = .white, textColor: Color = .white, style: DynamicNotch<InfoView>.Style = .auto) {
         internalDynamicNotch = DynamicNotch(style: style) {
-            InfoView(progress: progress, progressBarColor: progressBarColor, title: title, description: description, numberOverlay: progressText)
+            InfoView(progress: progress, progressBarColor: progressBarColor, title: title, description: description, textColor: textColor, numberOverlay: progressText)
         }
     }
 
-    public func setContent(progress: Binding<CGFloat>, title: String, description: String? = nil, progressText: Bool = false, progressBarColor: Color = .white) {
+    public func setContent(progress: Binding<CGFloat>, title: String, description: String? = nil, progressText: Bool = false, progressBarColor: Color = .white, textColor: Color = .white) {
         internalDynamicNotch.setContent {
-            InfoView(progress: progress, progressBarColor: progressBarColor, title: title, description: description, numberOverlay: progressText)
+            InfoView(progress: progress, progressBarColor: progressBarColor, title: title, description: description, textColor: textColor, numberOverlay: progressText)
         }
     }
 
-    public init(progress: Binding<CGFloat>, title: String, description: String? = nil, iconOverlay: Image! = nil, progressBarColor: Color = .white, style: DynamicNotch<InfoView>.Style = .auto) {
+    public init(progress: Binding<CGFloat>, title: String, description: String? = nil, iconOverlay: Image! = nil, progressBarColor: Color = .white, textColor: Color = .white, style: DynamicNotch<InfoView>.Style = .auto) {
         internalDynamicNotch = DynamicNotch(style: style) {
-            InfoView(progress: progress, progressBarColor: progressBarColor, title: title, description: description, iconOverlay: iconOverlay)
+            InfoView(progress: progress, progressBarColor: progressBarColor, title: title, description: description, textColor: textColor, iconOverlay: iconOverlay)
         }
     }
 
-    public func setContent(progress: Binding<CGFloat>, title: String, description: String? = nil, iconOverlay: Image! = nil, progressBarColor: Color = .white) {
+    public func setContent(progress: Binding<CGFloat>, title: String, description: String? = nil, iconOverlay: Image! = nil, progressBarColor: Color = .white, textColor: Color = .white) {
         internalDynamicNotch.setContent {
-            InfoView(progress: progress, progressBarColor: progressBarColor, title: title, description: description, iconOverlay: iconOverlay)
+            InfoView(progress: progress, progressBarColor: progressBarColor, title: title, description: description, textColor: textColor, iconOverlay: iconOverlay)
         }
     }
 
@@ -54,15 +54,17 @@ public extension DynamicNotchProgress {
 
         let title: String
         let description: String?
+        let textColor: Color
 
         let numberOverlay: Bool?
         let iconOverlay: Image?
 
-        init(progress: Binding<CGFloat>, progressBarColor: Color, title: String, description: String? = nil, numberOverlay: Bool? = nil, iconOverlay: Image? = nil) {
+        init(progress: Binding<CGFloat>, progressBarColor: Color, title: String, description: String? = nil, textColor: Color, numberOverlay: Bool? = nil, iconOverlay: Image? = nil) {
             _progress = progress
             self.progressBarColor = progressBarColor
             self.title = title
             self.description = description
+            self.textColor = textColor
             self.numberOverlay = numberOverlay
             self.iconOverlay = iconOverlay
         }
@@ -75,13 +77,13 @@ public extension DynamicNotchProgress {
                             if #available(macOS 13.0, *) {
                                 Text("\(Int(progress * 100))%")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundStyle(textColor)
                                     .contentTransition(.numericText()) // .numericText() is only available on macOS 13+
                                     .animation(.smooth, value: progress)
                             } else {
                                 Text("\(Int(progress * 100))%")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundStyle(textColor)
                             }
                         }
 
@@ -100,11 +102,12 @@ public extension DynamicNotchProgress {
             VStack(alignment: .leading) {
                 Text(title)
                     .font(.headline)
+                    .foregroundStyle(textColor)
 
                 if let description {
                     Text(description)
-                        .foregroundStyle(.secondary)
                         .font(.caption2)
+                        .foregroundStyle(textColor)
                 }
             }
         }


### PR DESCRIPTION
**Before:**
<img width="325" alt="Screenshot 2024-10-10 at 4 33 06 PM" src="https://github.com/user-attachments/assets/d8d15a47-e412-4e3c-8a69-4d98779d84ae"> <img width="347" alt="Screenshot 2024-10-10 at 4 33 06 PM (2)" src="https://github.com/user-attachments/assets/0662b590-9cdb-4117-b5f7-04413fbd66a4">

**After:**
<img width="278" alt="Screenshot 2024-10-10 at 6 10 31 PM (2)" src="https://github.com/user-attachments/assets/6585615e-c6b5-4f92-a294-d34748c3a17e"> <img width="261" alt="Screenshot 2024-10-10 at 6 10 31 PM" src="https://github.com/user-attachments/assets/27623965-0c25-4097-b36a-97eca182145e">

**Usage:**
```swift
let notch = DynamicNotchInfo(
    icon: Image(systemName: "figure"),
    title: "Figure",
    description: "Looks like a person",
    iconColor: .green,
    textColor: .green
)
notch.show(for: 3)
```
