### PR TITLE
Automatically set white foregroundColor on NotchView

### DIFF
--- a/Sources/DynamicNotchKit/DynamicNotch.swift
+++ b/Sources/DynamicNotchKit/DynamicNotch.swift
@@ -180,9 +180,9 @@ extension DynamicNotch {
 
         let view: NSView = {
             switch notchStyle {
-            case .notch: NSHostingView(rootView: NotchView(dynamicNotch: self))
+            case .notch: NSHostingView(rootView: NotchView(dynamicNotch: self).foregroundStyle(.white))
             case .floating: NSHostingView(rootView: NotchlessView(dynamicNotch: self))
-            case .auto: screen.hasNotch ? NSHostingView(rootView: NotchView(dynamicNotch: self)) : NSHostingView(rootView: NotchlessView(dynamicNotch: self))
+            case .auto: screen.hasNotch ? NSHostingView(rootView: NotchView(dynamicNotch: self).foregroundStyle(.white)) : NSHostingView(rootView: NotchlessView(dynamicNotch: self))
             }
         }()
 


### PR DESCRIPTION
Since the NotchView always has a black background no matter the current appearance mode (dark/light), it feels appropriate to select a default white foregroundStyle, that can be overriden in your own View when necessary.