### PR TITLE
Add configurable animation overrides and smooth transitions

### DIFF
--- a/Sources/DynamicNotchKit/DynamicNotch/DynamicNotch.swift
+++ b/Sources/DynamicNotchKit/DynamicNotch/DynamicNotch.swift
@@ -68,18 +68,8 @@ public final class DynamicNotch<Expanded, CompactLeading, CompactTrailing>: Obse
     /// Namespace for matched geometry effect. It is automatically generated if `nil` when the notch is first presented.
     @Published public internal(set) var namespace: Namespace.ID?
 
-    /// Optional animation overrides. When `nil`, falls back to the style's default animation.
-    public var openingAnimation: Animation?
-
-    /// Optional animation override for the closing transition. When `nil`, falls back to the style's default.
-    public var closingAnimation: Animation?
-
-    /// Optional animation override for compact ↔ expanded conversion. When `nil`, falls back to the style's default.
-    public var conversionAnimation: Animation?
-
-    /// When `true`, transitions between compact and expanded states skip the intermediate
-    /// hide step, resulting in a faster, more direct animation. Defaults to `false`.
-    public var smoothTransition: Bool = false
+    /// Configuration for customizing transition animations and behavior.
+    public var transitionConfiguration = DynamicNotchTransitionConfiguration()
 
     /// Content
     let expandedContent: Expanded
@@ -142,13 +132,13 @@ public final class DynamicNotch<Expanded, CompactLeading, CompactTrailing>: Obse
     }
 
     /// Resolves the effective opening animation (custom override or style default).
-    var effectiveOpeningAnimation: Animation { openingAnimation ?? style.openingAnimation }
+    var effectiveOpeningAnimation: Animation { transitionConfiguration.openingAnimation ?? style.openingAnimation }
 
     /// Resolves the effective closing animation (custom override or style default).
-    var effectiveClosingAnimation: Animation { closingAnimation ?? style.closingAnimation }
+    var effectiveClosingAnimation: Animation { transitionConfiguration.closingAnimation ?? style.closingAnimation }
 
     /// Resolves the effective conversion animation (custom override or style default).
-    var effectiveConversionAnimation: Animation { conversionAnimation ?? style.conversionAnimation }
+    var effectiveConversionAnimation: Animation { transitionConfiguration.conversionAnimation ?? style.conversionAnimation }
 
     /// Observes screen parameters changes and re-initializes the window if necessary.
     private func observeScreenParameters() {
@@ -181,7 +171,7 @@ public final class DynamicNotch<Expanded, CompactLeading, CompactTrailing>: Obse
 
 extension DynamicNotch {
     public func expand(on screen: NSScreen = NSScreen.screens[0]) async {
-        await _expand(on: screen, skipHide: smoothTransition)
+        await _expand(on: screen, skipHide: transitionConfiguration.skipIntermediateHides)
     }
 
     func _expand(on screen: NSScreen = NSScreen.screens[0], skipHide: Bool) async {
@@ -227,7 +217,7 @@ extension DynamicNotch {
     }
 
     public func compact(on screen: NSScreen = NSScreen.screens[0]) async {
-        await _compact(on: screen, skipHide: smoothTransition)
+        await _compact(on: screen, skipHide: transitionConfiguration.skipIntermediateHides)
     }
 
     func _compact(on screen: NSScreen = NSScreen.screens[0], skipHide: Bool) async {

--- a/Sources/DynamicNotchKit/DynamicNotch/DynamicNotch.swift
+++ b/Sources/DynamicNotchKit/DynamicNotch/DynamicNotch.swift
@@ -68,6 +68,19 @@ public final class DynamicNotch<Expanded, CompactLeading, CompactTrailing>: Obse
     /// Namespace for matched geometry effect. It is automatically generated if `nil` when the notch is first presented.
     @Published public internal(set) var namespace: Namespace.ID?
 
+    /// Optional animation overrides. When `nil`, falls back to the style's default animation.
+    public var openingAnimation: Animation?
+
+    /// Optional animation override for the closing transition. When `nil`, falls back to the style's default.
+    public var closingAnimation: Animation?
+
+    /// Optional animation override for compact ↔ expanded conversion. When `nil`, falls back to the style's default.
+    public var conversionAnimation: Animation?
+
+    /// When `true`, transitions between compact and expanded states skip the intermediate
+    /// hide step, resulting in a faster, more direct animation. Defaults to `false`.
+    public var smoothTransition: Bool = false
+
     /// Content
     let expandedContent: Expanded
     let compactLeadingContent: CompactLeading
@@ -79,7 +92,7 @@ public final class DynamicNotch<Expanded, CompactLeading, CompactTrailing>: Obse
     @Published private(set) var state: DynamicNotchState = .hidden
     @Published private(set) var notchSize: CGSize = .zero
     @Published private(set) var menubarHeight: CGFloat = 0
-    @Published private(set) var isHovering: Bool = false
+    @Published public private(set) var isHovering: Bool = false
 
     private var closePanelTask: Task<(), Never>? // Used to close the panel after hiding completes
 
@@ -128,6 +141,15 @@ public final class DynamicNotch<Expanded, CompactLeading, CompactTrailing>: Obse
         self.disableCompactTrailing = true
     }
 
+    /// Resolves the effective opening animation (custom override or style default).
+    var effectiveOpeningAnimation: Animation { openingAnimation ?? style.openingAnimation }
+
+    /// Resolves the effective closing animation (custom override or style default).
+    var effectiveClosingAnimation: Animation { closingAnimation ?? style.closingAnimation }
+
+    /// Resolves the effective conversion animation (custom override or style default).
+    var effectiveConversionAnimation: Animation { conversionAnimation ?? style.conversionAnimation }
+
     /// Observes screen parameters changes and re-initializes the window if necessary.
     private func observeScreenParameters() {
         Task {
@@ -159,7 +181,7 @@ public final class DynamicNotch<Expanded, CompactLeading, CompactTrailing>: Obse
 
 extension DynamicNotch {
     public func expand(on screen: NSScreen = NSScreen.screens[0]) async {
-        await _expand(on: screen, skipHide: false)
+        await _expand(on: screen, skipHide: smoothTransition)
     }
 
     func _expand(on screen: NSScreen = NSScreen.screens[0], skipHide: Bool) async {
@@ -174,7 +196,7 @@ extension DynamicNotch {
             initializeWindow(screen: screen, orderFront: false)
 
             // Start animation BEFORE showing window - this eliminates stutter
-            withAnimation(style.openingAnimation) {
+            withAnimation(effectiveOpeningAnimation) {
                 self.state = .expanded
             }
 
@@ -184,7 +206,7 @@ extension DynamicNotch {
             // Window exists and we're transitioning from compact state
             Task { @MainActor in
                 if !skipHide {
-                    withAnimation(style.closingAnimation) {
+                    withAnimation(effectiveClosingAnimation) {
                         self.state = .hidden
                     }
 
@@ -193,7 +215,7 @@ extension DynamicNotch {
                     try? await Task.sleep(for: .seconds(0.25))
                 }
 
-                withAnimation(style.conversionAnimation) {
+                withAnimation(effectiveConversionAnimation) {
                     self.state = .expanded
                 }
             }
@@ -205,7 +227,7 @@ extension DynamicNotch {
     }
 
     public func compact(on screen: NSScreen = NSScreen.screens[0]) async {
-        await _compact(on: screen, skipHide: false)
+        await _compact(on: screen, skipHide: smoothTransition)
     }
 
     func _compact(on screen: NSScreen = NSScreen.screens[0], skipHide: Bool) async {
@@ -230,7 +252,7 @@ extension DynamicNotch {
             initializeWindow(screen: screen, orderFront: false)
 
             // Start animation BEFORE showing window - this eliminates stutter
-            withAnimation(style.openingAnimation) {
+            withAnimation(effectiveOpeningAnimation) {
                 self.state = .compact
             }
 
@@ -240,7 +262,7 @@ extension DynamicNotch {
             // Window exists and we're transitioning from expanded state
             Task { @MainActor in
                 if !skipHide {
-                    withAnimation(style.closingAnimation) {
+                    withAnimation(effectiveClosingAnimation) {
                         self.state = .hidden
                     }
 
@@ -249,7 +271,7 @@ extension DynamicNotch {
                     guard self.state == .hidden else { return }
                 }
 
-                withAnimation(style.conversionAnimation) {
+                withAnimation(effectiveConversionAnimation) {
                     self.state = .compact
                 }
             }
@@ -283,7 +305,7 @@ extension DynamicNotch {
             return
         }
 
-        withAnimation(style.closingAnimation) {
+        withAnimation(effectiveClosingAnimation) {
             state = .hidden
             isHovering = false
         }

--- a/Sources/DynamicNotchKit/DynamicNotch/DynamicNotchTransitionConfiguration.swift
+++ b/Sources/DynamicNotchKit/DynamicNotch/DynamicNotchTransitionConfiguration.swift
@@ -1,0 +1,58 @@
+//
+//  DynamicNotchTransitionConfiguration.swift
+//  DynamicNotchKit
+//
+//  Created by Sebastian on 2025-06-13.
+//
+
+import SwiftUI
+
+/// Configuration for customizing transition animations of a ``DynamicNotch``.
+///
+/// Use this to override the default style-based animations and control
+/// how the notch transitions between states.
+///
+/// ```swift
+/// let notch = DynamicNotch(style: .auto) {
+///     Text("Hello")
+/// }
+/// notch.transitionConfiguration = .init(
+///     openingAnimation: .spring(duration: 0.3),
+///     skipIntermediateHides: true
+/// )
+/// ```
+public struct DynamicNotchTransitionConfiguration: Sendable {
+    /// Animation used when the notch appears (hidden → expanded or hidden → compact).
+    /// When `nil`, falls back to the style's default opening animation.
+    public var openingAnimation: Animation?
+
+    /// Animation used when the notch disappears (expanded → hidden or compact → hidden).
+    /// When `nil`, falls back to the style's default closing animation.
+    public var closingAnimation: Animation?
+
+    /// Animation used when converting between compact and expanded states.
+    /// When `nil`, falls back to the style's default conversion animation.
+    public var conversionAnimation: Animation?
+
+    /// When `true`, transitions between compact and expanded states skip the intermediate
+    /// hide step, resulting in a faster, more direct animation.
+    public var skipIntermediateHides: Bool
+
+    /// Creates a new transition configuration.
+    /// - Parameters:
+    ///   - openingAnimation: Custom opening animation, or `nil` to use the style default.
+    ///   - closingAnimation: Custom closing animation, or `nil` to use the style default.
+    ///   - conversionAnimation: Custom conversion animation, or `nil` to use the style default.
+    ///   - skipIntermediateHides: Whether to skip the hide step when converting between states. Defaults to `false`.
+    public init(
+        openingAnimation: Animation? = nil,
+        closingAnimation: Animation? = nil,
+        conversionAnimation: Animation? = nil,
+        skipIntermediateHides: Bool = false
+    ) {
+        self.openingAnimation = openingAnimation
+        self.closingAnimation = closingAnimation
+        self.conversionAnimation = conversionAnimation
+        self.skipIntermediateHides = skipIntermediateHides
+    }
+}


### PR DESCRIPTION
## Summary

- Adds optional `openingAnimation`, `closingAnimation`, `conversionAnimation` properties to `DynamicNotch` — when set, they override the style's default animations. When `nil` (the default), behavior is unchanged.
- Adds `smoothTransition` boolean — when `true`, `expand()` and `compact()` skip the intermediate hide step, converting directly between states for a faster, more fluid transition.
- Makes `isHovering` publicly readable (`public private(set)`) so consumers can react to hover state changes.

All changes are additive and backwards-compatible. Existing consumers see no behavior change.

## Motivation

When building an app that lives in the notch and toggles between compact/expanded on hover, the default `expand()` → hide → re-expand flow adds ~250ms of unnecessary delay. `smoothTransition = true` skips this, and custom animation durations allow tuning the feel for different use cases (e.g., snappier for interactive UIs, slower for notifications).

Making `isHovering` public enables reactive patterns like expand-on-hover without resorting to workarounds like NSEvent monitors.

## Test Plan

- [x] `swift build` passes with no warnings
- [x] Verify default behavior unchanged (no properties set)
- [x] Verify `smoothTransition = true` skips hide step on compact↔expanded
- [x] Verify custom animation overrides are applied
- [x] Verify `isHovering` is readable from consuming modules